### PR TITLE
Update to Create 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,15 +8,20 @@ plugins {
 
 repositories {
     maven {
-        name = 'tterrag maven'
+        name = 'tterrag maven' // Registrate
         url = 'https://maven.tterrag.com/'
     }
+    maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
 }
 
 dependencies {
-    implementation fg.deobf("com.simibubi.create:create-${create_minecraft_version}:${create_version}:slim") { transitive = false }
-    implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${flywheel_minecraft_version}:${flywheel_version}")
-    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
+    implementation(fg.deobf("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false })
+    implementation(fg.deobf("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}"))
+    compileOnly(fg.deobf("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:${flywheel_version}"))
+    runtimeOnly(fg.deobf("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_version}"))
+    implementation(fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}"))
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
+    implementation("io.github.llamalad7:mixinextras-forge:0.4.1")
 }
 
 version = mod_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,10 +37,9 @@ mapping_channel=official
 # This must match the format required by the mapping channel.
 mapping_version=1.20.1
 
-create_minecraft_version = 1.20.1
-flywheel_minecraft_version = 1.20
-create_version = 0.5.1.d-9
-flywheel_version = 0.6.9-4
+create_version = 6.0.2-50
+ponder_version = 1.0.51
+flywheel_version = 1.0.1
 registrate_version = MC1.20-1.3.3
 
 ## Mod Properties

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -65,7 +65,7 @@ description='''${mod_description}'''
 [[dependencies.${mod_id}]]
     modId="create"
     mandatory=true
-    versionRange="[0.5.1.c,)"
+    versionRange="[6.0.2,6.1.0)"
     ordering="NONE"
     side="BOTH"
 

--- a/src/main/resources/mixins.create_trains_on_trains.json
+++ b/src/main/resources/mixins.create_trains_on_trains.json
@@ -3,7 +3,7 @@
   "minVersion": "0.8",
   "package": "sindarin.create_trains_on_trains.mixin",
   "compatibilityLevel": "JAVA_17",
-  "refmap": "create_trains_on_trains.refmap.json",
+  "refmap": "mixins.create_trains_on_trains.refmap.json",
   "mixins": [
     "MixinCarriageContraption"
   ]


### PR DESCRIPTION
Your mixin target got removed. Moved it forward one instruction so now we have to check whether the block is a bogey.

Adds one more method because an optimization to not have both the bogey BE and the contraption rendering wheels meant that trains on trains rendered without bogeys.

Also fixes #1 because refmap is now necessary.
Prefixes your mixin methods because that's more compatible.